### PR TITLE
Cite patch release of rust-security-framework.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,21 @@ name = "instantiation"
 keyring-core = { version = "0.4" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = { version = "3", features=["OSX_10_13"], git = "https://github.com/brotskydotcom/rust-security-framework", branch = "composite" }
-security-framework-sys = { version = "2", features=["OSX_10_13"], git = "https://github.com/brotskydotcom/rust-security-framework", branch = "composite" }
+security-framework = { version = "3.4", features=["OSX_10_13"] }
+security-framework-sys = { version = "2.15", features=["OSX_10_13"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-security-framework = { version = "3", features=["OSX_10_13"], git = "https://github.com/brotskydotcom/rust-security-framework", branch = "composite" }
-security-framework-sys = { version = "2", features=["OSX_10_13"], git = "https://github.com/brotskydotcom/rust-security-framework", branch = "composite" }
+security-framework = { version = "3.4", features=["OSX_10_13"] }
+security-framework-sys = { version = "2.15", features=["OSX_10_13"] }
 
 [dev-dependencies]
 fastrand = "2"
 env_logger = "0.11"
 log = "0.4"
+
+[patch.crates-io]
+security-framework = { git = "https://github.com/brotskydotcom/rust-security-framework.git", branch = "composite" }
+security-framework-sys = { git = "https://github.com/brotskydotcom/rust-security-framework.git", branch = "composite" }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"


### PR DESCRIPTION
In order to publish, we have to use patch release of the rust-security-framework.